### PR TITLE
ci-image: install libxml2

### DIFF
--- a/actions-support/ci-image/Dockerfile
+++ b/actions-support/ci-image/Dockerfile
@@ -86,7 +86,9 @@ FROM ubuntu:latest as final
 ARG TARGETARCH
 
 # Make sure we have git, as it's needed at runtime
-RUN apt-get update && apt-get install -y git libxml2 && rm -rf /var/lib/apt/lists/*
+# libxml2 is required for fmt task
+# doxygen required for docs
+RUN apt-get update && apt-get install -y git libxml2 doxygen && rm -rf /var/lib/apt/lists/*
 
 # Insert the DBT itself
 COPY --from=builder /dbt /dbt

--- a/actions-support/ci-image/Dockerfile
+++ b/actions-support/ci-image/Dockerfile
@@ -86,7 +86,7 @@ FROM ubuntu:latest as final
 ARG TARGETARCH
 
 # Make sure we have git, as it's needed at runtime
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y git libxml2 && rm -rf /var/lib/apt/lists/*
 
 # Insert the DBT itself
 COPY --from=builder /dbt /dbt

--- a/actions-support/simulate_ci_image_build.sh
+++ b/actions-support/simulate_ci_image_build.sh
@@ -12,7 +12,8 @@ cp ../dist/dbt-toolchain-*-linux*.tar.gz ./ci-image/dist/
 
 # Run the build
 docker buildx build \
-  --platform linux/amd64,linux/arm64 \
+  --platform linux/amd64 \
+  --load \
   -t deluge-ci-image:latest \
   -f ./ci-image/Dockerfile \
   --build-arg DBT_VERSION=$(cat ../VERSION) \


### PR DESCRIPTION
This is not strictly required for CI, but it is small and allows us to run `clang-format` inside the container environment.